### PR TITLE
Add some options to Losers and Gainers commands 

### DIFF
--- a/i8_terminal/commands/price/price_list.py
+++ b/i8_terminal/commands/price/price_list.py
@@ -48,8 +48,8 @@ def format_hist_price_df(df: DataFrame, target: str) -> DataFrame:
     default="1M",
     help="Historical price period.",
 )
-@click.option("--from_date", "-f", type=DateTime(), help="Histotical price from date.")
-@click.option("--to_date", "-t", type=DateTime(), help="Histotical price to date.")
+@click.option("--from_date", "-f", type=DateTime(), help="Historical price from date.")
+@click.option("--to_date", "-t", type=DateTime(), help="Historical price to date.")
 @click.option("--export", "export_path", "-e", help="Filename to export the output to.")
 @pass_command
 def list(

--- a/i8_terminal/commands/screen/screen_gainers.py
+++ b/i8_terminal/commands/screen/screen_gainers.py
@@ -1,12 +1,15 @@
-from typing import Optional
+from typing import Optional, cast
 
+import arrow
 import click
+from click.types import DateTime
 from rich.console import Console
 
 from i8_terminal.commands.screen import screen
 from i8_terminal.common.cli import pass_command
 from i8_terminal.common.screen import get_top_stocks_df, render_top_stocks
 from i8_terminal.types.market_indice_param_type import MarketIndiceParamType
+from i8_terminal.types.metric_identifier_param_type import MetricIdentifierParamType
 from i8_terminal.types.metric_view_param_type import MetricViewParamType
 
 
@@ -22,8 +25,18 @@ from i8_terminal.types.metric_view_param_type import MetricViewParamType
     "--view_name", "view_name", "-v", type=MetricViewParamType(), help="Metric view name in configuration file."
 )
 @click.option("--export", "export_path", "-e", help="Filename to export the output to.")
+@click.option("--metrics", "metrics", "-m", type=MetricIdentifierParamType(), help="Additional metrices to analyse.")
+@click.option("--count", "count", "-c", default=10, help="Number of results shown.")
+@click.option("--date", "date", "-d", type=DateTime(), help="Date on which the analysis is perfomed on.")
 @pass_command
-def gainers(index: str, view_name: Optional[str], export_path: Optional[str]) -> None:
+def gainers(
+    index: str,
+    view_name: Optional[str],
+    date: Optional[DateTime],
+    metrics: Optional[str],
+    count: Optional[int],
+    export_path: Optional[str],
+) -> None:
     """
     Lists today winner companies.
 
@@ -34,7 +47,7 @@ def gainers(index: str, view_name: Optional[str], export_path: Optional[str]) ->
     """
     console = Console()
     with console.status("Fetching data...", spinner="material"):
-        df = get_top_stocks_df("winners", index, view_name)
+        df = get_top_stocks_df("winners", index, view_name, arrow.get(date).datetime, count, metrics)
     if df is None:
         console.print("No data found for today winners", style="yellow")
         return

--- a/i8_terminal/commands/screen/screen_losers.py
+++ b/i8_terminal/commands/screen/screen_losers.py
@@ -1,12 +1,14 @@
-from typing import Optional
+from typing import Optional, cast
 
 import click
+from click.types import DateTime
 from rich.console import Console
 
 from i8_terminal.commands.screen import screen
 from i8_terminal.common.cli import pass_command
 from i8_terminal.common.screen import get_top_stocks_df, render_top_stocks
 from i8_terminal.types.market_indice_param_type import MarketIndiceParamType
+from i8_terminal.types.metric_identifier_param_type import MetricIdentifierParamType
 from i8_terminal.types.metric_view_param_type import MetricViewParamType
 
 
@@ -22,8 +24,18 @@ from i8_terminal.types.metric_view_param_type import MetricViewParamType
     "--view_name", "view_name", "-v", type=MetricViewParamType(), help="Metric view name in configuration file."
 )
 @click.option("--export", "export_path", "-e", help="Filename to export the output to.")
+@click.option("--metrics", "metrics", "-m", type=MetricIdentifierParamType(), help="Additional metrices to analyse.")
+@click.option("--count", "count", "-c", default=10, help="Number of results shown.")
+@click.option("--date", "date", "-d", type=DateTime(), help="Date on which the analysis is perfomed on.")
 @pass_command
-def losers(index: str, view_name: Optional[str], export_path: Optional[str]) -> None:
+def losers(
+    index: str,
+    view_name: Optional[str],
+    date: Optional[DateTime],
+    metrics: Optional[str],
+    count: Optional[int],
+    export_path: Optional[str],
+) -> None:
     """
     Lists today loser companies.
 
@@ -34,7 +46,7 @@ def losers(index: str, view_name: Optional[str], export_path: Optional[str]) -> 
     """
     console = Console()
     with console.status("Fetching data...", spinner="material"):
-        df = get_top_stocks_df("losers", index, view_name)
+        df = get_top_stocks_df("losers", index, view_name, cast(str, date), count, metrics)
     if df is None:
         console.print("No data found for today losers", style="yellow")
         return

--- a/i8_terminal/common/metrics.py
+++ b/i8_terminal/common/metrics.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import arrow
 import investor8_sdk
@@ -117,7 +117,7 @@ def get_period_start_date(period: str) -> str:
     return period_start_date[period]
 
 
-def get_current_metrics_df(tickers: str, metricsList: str) -> Optional[pd.DataFrame]:
+def get_current_metrics_df(tickers: str, metricsList: Union[str, Any, None]) -> Optional[pd.DataFrame]:
     metrics = investor8_sdk.MetricsApi().get_current_metrics(
         symbols=tickers,
         metrics=metricsList,

--- a/i8_terminal/common/screen.py
+++ b/i8_terminal/common/screen.py
@@ -1,7 +1,9 @@
 from typing import Any, Dict, Optional
 
+import click
 import investor8_sdk
 import pandas as pd
+from click.types import DateTime
 from rich.table import Table
 
 from i8_terminal.common.layout import df2Table
@@ -13,13 +15,23 @@ from i8_terminal.common.utils import export_data, export_to_html
 from i8_terminal.config import APP_SETTINGS
 
 
-def get_top_stocks_df(category: str, index: str, view_name: Optional[str]) -> Optional[pd.DataFrame]:
-    metrics = APP_SETTINGS["commands"]["screen_gainers"]["metrics"]
-    companies_data = investor8_sdk.ScreenerApi().get_top_stocks(category, index=index)
+def get_top_stocks_df(
+    category: str,
+    index: str,
+    view_name: Optional[str],
+    date: Optional[DateTime],
+    count: Optional[int],
+    metrics: Optional[str],
+) -> Optional[pd.DataFrame]:
+    if metrics is None:
+        metrics = APP_SETTINGS["commands"]["screen_gainers"]["metrics"]
+    else:
+        metrics = APP_SETTINGS["commands"]["screen_gainers"]["metrics"] + "," + metrics
+    companies_data = investor8_sdk.ScreenerApi().get_top_stocks(category, index=index, _date=date, count=count)
     if companies_data is None:
         return None
     companies = [company.ticker for company in companies_data]
-    if view_name:
+    if view_name and metrics:
         metrics = metrics + "," + APP_SETTINGS["metric_view"][view_name]["metrics"]
     return get_current_metrics_df(",".join(companies), metrics)
 

--- a/i8_terminal/types/metric_identifier_param_type.py
+++ b/i8_terminal/types/metric_identifier_param_type.py
@@ -18,7 +18,7 @@ class MetricIdentifierParamType(AutoCompleteChoice):
         if param_type == "metric":
             return self._metric_auto_comp.get_suggestions(keyword)
         else:
-            return self._period_auto_comp.get_suggestions(keyword, metric=metric)
+            return self._period_auto_comp.get_suggestions(keyword, True, metric=metric)
 
     def __repr__(self) -> str:
         return "METRICIDENTIFIER"


### PR DESCRIPTION
Add --metrics options (should be similar to watchlist command)
Add --count option (corresponds to the count parameter of the API)
Add --date option (corresponds to the date option). Make sure the auto

Have not added: List of [U.S. Stock / DOW 30 / NASDAQ / S&P 500] Gainers/Losers on 2022-11-06